### PR TITLE
Fix garbled repeating fields

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -348,9 +348,11 @@ def expand_form_composite(data, fieldnames):
     indexes = dict((key, {}) for key in fieldnames)
 
     # pad indexes with leading zeros so that sorting of 10 items or more works correctly
+    # we must itirate over sorted data to insure all keys are populated in time.
+    # there is probable a better way to do this.
     # TODO: make this change to the indexes when they are first stored, likely
     # need updating scheming_flatten_subfield and others.
-    for key in data:
+    for key in sorted(data):
         if sep not in key:
             continue
         parts = key.split(sep)
@@ -380,17 +382,6 @@ def expand_form_composite(data, fieldnames):
                 del data[key]
         except (IndexError, ValueError):
             pass  # best-effort only
-
-    # remove padding of indexes, this might not be needed if all keys have
-    # been merged and removed
-    for key in data:
-        if sep not in key:
-            continue
-        parts = key.split(sep)
-        if parts[0] not in fieldnames:
-            continue
-        parts[1] = parts[1].lstrip('0')
-        data[sep.join(parts)] = data.pop(key)
 
 def expand_form_simple_composite(data, fieldnames):
     """

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 
 from ckantoolkit.tests.factories import Sysadmin, Dataset
 from ckantoolkit.tests.helpers import call_action
-        
+
 import ckan.plugins.toolkit as toolkit
 sep = toolkit.h.scheming_composite_separator()
 
@@ -403,7 +403,7 @@ class TestSimpleSubfieldDatasetForm(object):
             app.post(url.encode('ascii'), params=data, extra_environ=sysadmin_env)
 
         dataset = call_action("package_show", id="subfield_dataset_1")
-        assert dataset["temporal_extent"] == {'begin': '2000-01-23', 'end': '2021-12-30'}
+        assert dataset["temporal_extent"] == [{'begin': '2000-01-23', 'end': '2021-12-30'}]
 
     def test_dataset_form_update_simple_subfield(self, app):
         dataset = Dataset(
@@ -431,7 +431,7 @@ class TestSimpleSubfieldDatasetForm(object):
 
         dataset = call_action("package_show", id=dataset["id"])
 
-        assert dataset["temporal_extent"] == {'begin': '1989-04-13', 'end': '1995-05-15'}
+        assert dataset["temporal_extent"] == [{'begin': '1989-04-13', 'end': '1995-05-15'}]
 
 @pytest.mark.usefixtures("clean_db")
 class TestSubfieldResourceForm(object):

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -909,7 +909,7 @@ class TestSimpleSubfieldDatasetValid(object):
             temporal_extent=[{'begin': '2000-01-23', 'end': ''}]
         )
 
-        assert dataset["temporal_extent"] == {'begin': '2000-01-23'}
+        assert dataset["temporal_extent"] == [{'begin': '2000-01-23'}]
 
     def test_empty_simple_subfields(self):
         lc = LocalCKAN()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pyyaml==5.4',
+        'pyyaml',
         'ckanapi',
         'ckantoolkit>=0.0.2',
         'pytz',


### PR DESCRIPTION
When a dataset contains a repeating field with more than 9 entries it corrupts all repeating fields. this was due to the index lookup being reused between all repeating fields. If the a field of more then 9 entries was encountered the index lookup would be populated as {'10':0, '11:1, '1':2, '2':3...} If the next repeating field had only 2 entries, for example, it would still map index 1 to array position 2 which would be out of bounds and thus drop the data

This pr adds:
- pad index number in repeating fields so that they keys sort correctly in the data dictionary. 
- split the index lookup dictionary up into separate indexes for each repeating field rather than reusing the same index lookup for all repeating fields.